### PR TITLE
Improve profile design with brand colors

### DIFF
--- a/apps/mobile/constants/colors.ts
+++ b/apps/mobile/constants/colors.ts
@@ -2,9 +2,9 @@ export const temas = {
   claro: {
     fondo: "#ffffff",
     texto: "#1a1a1a",
-    primario: "#2196F3",
-    secundario: "#f2f2f2",
-    exito: "#4CAF50",
+    primario: "#0057A5",
+    secundario: "#FF3E3E",
+    exito: "#24A148",
     peligro: "#D32F2F",
     gris: "#999999",
     borde: "#D9D9D9",
@@ -12,7 +12,7 @@ export const temas = {
   oscuro: {
     fondo: "#121212",
     texto: "#f5f5f5",
-    primario: "#2196F3",
+    primario: "#0057A5",
     secundario: "#1e1e1e",
     exito: "#81C784",
     peligro: "#ef5350",

--- a/apps/mobile/screens/PerfilScreen.tsx
+++ b/apps/mobile/screens/PerfilScreen.tsx
@@ -73,49 +73,47 @@ export default function PerfilScreen({ route, navigation }: any) {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.fondo }]}>
-      {foto ? (
-        <Image source={{ uri: foto }} style={styles.avatar} />
-      ) : (
-        <View
-          style={[styles.avatarPlaceholder, { backgroundColor: colors.gris }]}
-        >
-          <Text style={styles.avatarInicial}>{nombre.charAt(0)}</Text>
-        </View>
-      )}
-
-      <Text style={[styles.nombre, { color: colors.texto }]}>{nombre}</Text>
-      {email ? (
-        <Text style={[styles.email, { color: colors.gris }]}>{email}</Text>
-      ) : null}
-
-      <View style={styles.suscripcionBox}>
-        <Text style={[styles.subTitulo, { color: colors.texto }]}>
-          Estado de suscripción
-        </Text>
-        {suscripcion?.activa ? (
-          <Text style={{ color: colors.exito }}>
-            Activa hasta {suscripcion.expiracion}
-          </Text>
+      <View style={styles.card}>
+        {foto ? (
+          <Image source={{ uri: foto }} style={styles.avatar} />
         ) : (
-          <Text style={{ color: colors.peligro }}>
-            No tienes suscripción activa
-          </Text>
+          <View
+            style={[styles.avatarPlaceholder, { backgroundColor: colors.primario }]}
+          >
+            <Text style={styles.avatarInicial}>{nombre.charAt(0)}</Text>
+          </View>
         )}
+
+        <Text style={[styles.nombre, { color: colors.texto }]}>{nombre}</Text>
+        {email ? (
+          <Text style={[styles.email, { color: colors.gris }]}>{email}</Text>
+        ) : null}
+
+        <View style={styles.suscripcionBox}>
+          <Text style={[styles.subTitulo, { color: colors.texto }]}>Estado de suscripción</Text>
+          {suscripcion?.activa ? (
+            <Text style={{ color: colors.exito }}>
+              Activa hasta {suscripcion.expiracion}
+            </Text>
+          ) : (
+            <Text style={{ color: colors.peligro }}>No tienes suscripción activa</Text>
+          )}
+        </View>
+
+        <TouchableOpacity
+          style={[styles.botonSecundario, { backgroundColor: colors.primario }]}
+          onPress={() => navigation.navigate("Configuracion")}
+        >
+          <Text style={styles.botonTexto}>Configuración de DomiChat</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.botonCerrar, { backgroundColor: colors.peligro }]}
+          onPress={cerrarSesion}
+        >
+          <Text style={styles.botonTexto}>Cerrar sesión</Text>
+        </TouchableOpacity>
       </View>
-
-      <TouchableOpacity
-        style={[styles.botonSecundario, { backgroundColor: colors.primario }]}
-        onPress={() => navigation.navigate("Configuracion")}
-      >
-        <Text style={styles.botonTexto}>Configuración de DomiChat</Text>
-      </TouchableOpacity>
-
-      <TouchableOpacity
-        style={[styles.botonCerrar, { backgroundColor: colors.peligro }]}
-        onPress={cerrarSesion}
-      >
-        <Text style={styles.botonTexto}>Cerrar sesión</Text>
-      </TouchableOpacity>
     </View>
   )
 }
@@ -128,6 +126,18 @@ const styles = StyleSheet.create({
     paddingTop: 48,
     paddingLeft: 24,
     paddingRight: 24,
+  },
+  card: {
+    width: "100%",
+    alignItems: "center",
+    backgroundColor: "#fff",
+    padding: 24,
+    borderRadius: 12,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
   },
   centered: {
     flex: 1,
@@ -155,6 +165,7 @@ const styles = StyleSheet.create({
   nombre: {
     fontSize: 20,
     fontWeight: "bold",
+    marginBottom: 4,
   },
   email: {
     fontSize: 14,

--- a/apps/web/pages/perfil.tsx
+++ b/apps/web/pages/perfil.tsx
@@ -41,26 +41,29 @@ export default function Perfil() {
     <>
       <Header />
       <div style={styles.wrapper}>
-        <h2 style={styles.titulo}>👤 {nombre}</h2>
+        <div style={styles.card}>
+          <div style={styles.avatar}>{nombre.charAt(0).toUpperCase()}</div>
+          <h2 style={styles.titulo}>{nombre}</h2>
 
-        {estado ? (
-          estado.activa ? (
-            <p style={styles.activa}>
-              ✅ Suscripción activa hasta el{" "}
-              {new Date(estado.expiracion!).toLocaleDateString()}
-            </p>
+          {estado ? (
+            estado.activa ? (
+              <p style={styles.activa}>
+                Suscripción activa hasta el{" "}
+                {new Date(estado.expiracion!).toLocaleDateString()}
+              </p>
+            ) : (
+              <p style={styles.inactiva}>No tienes una suscripción activa</p>
+            )
           ) : (
-            <p style={styles.inactiva}>🚫 No tienes una suscripción activa</p>
-          )
-        ) : (
-          <p style={{ color: colors.texto }}>
-            Cargando estado de suscripción...
-          </p>
-        )}
+            <p style={{ color: colors.texto }}>
+              Cargando estado de suscripción...
+            </p>
+          )}
 
-        <button style={styles.boton} onClick={cerrarSesion}>
-          Cerrar sesión
-        </button>
+          <button style={styles.boton} onClick={cerrarSesion}>
+            Cerrar sesión
+          </button>
+        </div>
       </div>
     </>
   )
@@ -75,10 +78,30 @@ const styles: { [key: string]: React.CSSProperties } = {
     paddingRight: 16,
     textAlign: "center",
   },
+  card: {
+    backgroundColor: "#fff",
+    border: `1px solid ${colors.borde}`,
+    borderRadius: 12,
+    padding: 24,
+    boxShadow: "0 2px 8px rgba(0,0,0,0.05)",
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    borderRadius: "50%",
+    backgroundColor: colors.primario,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "#fff",
+    fontSize: 32,
+    fontWeight: 700,
+    margin: "0 auto 20px",
+  },
   titulo: {
-    fontSize: 24,
+    fontSize: 22,
     color: colors.primario,
-    marginBottom: 30,
+    marginBottom: 20,
     fontWeight: 700,
   },
   activa: {


### PR DESCRIPTION
## Summary
- enhance web profile layout with avatar card styling
- refresh mobile profile screen with card layout
- apply DomiChat color palette across the mobile app

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68457494bb2c8333ba4ec7ed242a85dd