### PR TITLE
Add headers in chat and history screens

### DIFF
--- a/apps/mobile/components/Header.tsx
+++ b/apps/mobile/components/Header.tsx
@@ -1,0 +1,33 @@
+import React, { useContext } from "react"
+import { View, Text, StyleSheet } from "react-native"
+import { ThemeContext } from "../context/ThemeContext"
+import { temas } from "../constants/colors"
+
+export default function Header({ titulo }: { titulo: string }) {
+  const { tema } = useContext(ThemeContext)
+  const colors = temas[tema]
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.fondo, borderBottomColor: colors.borde },
+      ]}
+    >
+      <Text style={[styles.titulo, { color: colors.texto }]}>{titulo}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: 56,
+    alignItems: "center",
+    justifyContent: "center",
+    borderBottomWidth: 1,
+  },
+  titulo: {
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+})

--- a/apps/mobile/screens/ChatScreen.tsx
+++ b/apps/mobile/screens/ChatScreen.tsx
@@ -17,6 +17,7 @@ import { generarTitulo } from "../utils/generarTitulo"
 import axios from "axios"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import Header from "../components/Header"
 
 export default function ChatScreen({ route }: any) {
   const params = route?.params || {}
@@ -139,6 +140,7 @@ export default function ChatScreen({ route }: any) {
       keyboardVerticalOffset={Platform.OS === "ios" ? 100 : 80}
       style={{ flex: 1, backgroundColor: colors.fondo }}
     >
+      <Header titulo="Chat" />
       {historial.length === 0 ? (
         <View style={styles.emptyContainer}>
           <Text style={[styles.emptyTitulo, { color: colors.texto }]}>

--- a/apps/mobile/screens/HistorialScreen.tsx
+++ b/apps/mobile/screens/HistorialScreen.tsx
@@ -16,6 +16,7 @@ import axios from "axios"
 import { BASE_URL } from "../services/api"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import Header from "../components/Header"
 
 export default function HistorialScreen({ navigation }: any) {
   const [historial, setHistorial] = useState<any[]>([])
@@ -122,6 +123,7 @@ export default function HistorialScreen({ navigation }: any) {
   if (cargando) {
     return (
       <View style={[styles.centered, { backgroundColor: colors.fondo }]}>
+        <Header titulo="Historial" />
         <ActivityIndicator size="large" color={colors.primario} />
         <Text style={{ marginTop: 10, color: colors.texto }}>
           Cargando historial...
@@ -133,6 +135,7 @@ export default function HistorialScreen({ navigation }: any) {
   if (historial.length === 0) {
     return (
       <View style={[styles.centered, { backgroundColor: colors.fondo }]}>
+        <Header titulo="Historial" />
         <Text style={{ color: colors.texto }}>
           No tienes conversaciones guardadas aún.
         </Text>
@@ -142,6 +145,7 @@ export default function HistorialScreen({ navigation }: any) {
 
   return (
     <ScrollView style={{ backgroundColor: colors.fondo, padding: 16 }}>
+      <Header titulo="Historial" />
       {historial.map((item) => (
         <View
           key={item.id}

--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -24,6 +24,9 @@ export default function Header() {
         <Link href="/chat" style={styles.link}>
           Chat
         </Link>
+        <Link href="/historial" style={styles.link}>
+          Historial
+        </Link>
         <Link href="/perfil" style={styles.link}>
           Perfil
         </Link>

--- a/apps/web/pages/historial.tsx
+++ b/apps/web/pages/historial.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react"
+import axios from "axios"
+import Header from "../components/Header"
+import { colors } from "../constants/colors"
+import { verificarSesion } from "../services/auth"
+
+interface HistItem {
+  id: string
+  titulo: string
+  fecha: string
+}
+
+export default function Historial() {
+  const [items, setItems] = useState<HistItem[]>([])
+
+  useEffect(() => {
+    const sesion = verificarSesion()
+    if (!sesion) return
+
+    axios
+      .get("http://localhost:4000/api/chat/historial", {
+        headers: { Authorization: `Bearer ${sesion.token}` },
+      })
+      .then((res) => setItems(res.data))
+      .catch(() => {})
+  }, [])
+
+  return (
+    <>
+      <Header />
+      <div style={styles.wrapper}>
+        <h2 style={styles.titulo}>Historial de conversaciones</h2>
+        {items.length === 0 ? (
+          <p>No tienes conversaciones guardadas aún.</p>
+        ) : (
+          <ul style={{ listStyle: "none", paddingLeft: 0 }}>
+            {items.map((item) => (
+              <li key={item.id} style={styles.card}>
+                <p style={styles.tituloChat}>{item.titulo}</p>
+                <p style={styles.fecha}>
+                  {new Date(item.fecha).toLocaleDateString()} {" "}
+                  {new Date(item.fecha).toLocaleTimeString()}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}
+
+const styles: { [key: string]: React.CSSProperties } = {
+  wrapper: {
+    maxWidth: 800,
+    margin: "auto",
+    paddingTop: 30,
+    paddingLeft: 16,
+    paddingRight: 16,
+  },
+  titulo: {
+    color: colors.primario,
+    fontWeight: 700,
+    marginBottom: 20,
+  },
+  card: {
+    backgroundColor: "#fff",
+    border: `1px solid ${colors.borde}`,
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: 12,
+  },
+  tituloChat: {
+    fontWeight: 600,
+    marginBottom: 4,
+  },
+  fecha: {
+    color: colors.texto,
+    fontSize: 14,
+  },
+}


### PR DESCRIPTION
## Summary
- add reusable header component for mobile
- display header in mobile chat and history screens
- add history page to web and link in header
- update web header navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845751f0a348333b6c51923dab71ddd