### PR TITLE
Add greeting to mobile chat header

### DIFF
--- a/apps/mobile/screens/ChatScreen.tsx
+++ b/apps/mobile/screens/ChatScreen.tsx
@@ -140,7 +140,7 @@ export default function ChatScreen({ route }: any) {
       keyboardVerticalOffset={Platform.OS === "ios" ? 100 : 80}
       style={{ flex: 1, backgroundColor: colors.fondo }}
     >
-      <Header titulo="Chat" />
+      <Header titulo={`Hola, ${nombre.split(" ")[0]} 👋`} />
       {historial.length === 0 ? (
         <View style={styles.emptyContainer}>
           <Text style={[styles.emptyTitulo, { color: colors.texto }]}>


### PR DESCRIPTION
## Summary
- show user's name in the chat header on mobile

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684702d467708333aa7751b55058cf3f