### PR TITLE
Fix mobile history header layout

### DIFF
--- a/apps/mobile/components/Header.tsx
+++ b/apps/mobile/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react"
 import { View, Text, StyleSheet } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
 
@@ -8,14 +9,16 @@ export default function Header({ titulo }: { titulo: string }) {
   const colors = temas[tema]
 
   return (
-    <View
-      style={[
-        styles.container,
-        { backgroundColor: colors.primario, borderBottomColor: colors.primario },
-      ]}
-    >
-      <Text style={[styles.titulo, { color: "#fff" }]}>{titulo}</Text>
-    </View>
+    <SafeAreaView style={{ backgroundColor: colors.primario }} edges={["top"]}>
+      <View
+        style={[
+          styles.container,
+          { backgroundColor: colors.primario, borderBottomColor: colors.primario },
+        ]}
+      >
+        <Text style={[styles.titulo, { color: "#fff" }]}>{titulo}</Text>
+      </View>
+    </SafeAreaView>
   )
 }
 

--- a/apps/mobile/screens/HistorialScreen.tsx
+++ b/apps/mobile/screens/HistorialScreen.tsx
@@ -144,8 +144,9 @@ export default function HistorialScreen({ navigation }: any) {
   }
 
   return (
-    <ScrollView style={{ backgroundColor: colors.fondo, padding: 16 }}>
+    <View style={{ flex: 1, backgroundColor: colors.fondo }}>
       <Header titulo="Historial" />
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
       {historial.map((item) => (
         <View
           key={item.id}
@@ -241,7 +242,8 @@ export default function HistorialScreen({ navigation }: any) {
           </View>
         </View>
       </Modal>
-    </ScrollView>
+      </ScrollView>
+    </View>
   )
 }
 


### PR DESCRIPTION
## Summary
- fix history screen layout so the header fills the width
- add SafeAreaView to mobile Header to avoid notch overlap

## Testing
- `npx tsc -p apps/mobile/tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68470383ff608333855693c182805e3f