### PR TITLE
Add empty state to web chat

### DIFF
--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -190,6 +190,28 @@ export default function Chat() {
       fontWeight: 600,
       cursor: "pointer",
     },
+    emptyContainer: {
+      flex: 1,
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: 24,
+      textAlign: "center",
+    },
+    emptyTitulo: {
+      fontSize: 20,
+      fontWeight: 700,
+      marginBottom: 12,
+      textAlign: "center",
+      color: colors.texto,
+    },
+    emptyTexto: {
+      fontSize: 14,
+      textAlign: "center",
+      lineHeight: "20px",
+      color: colors.gris,
+    },
   }
 
   return (
@@ -198,26 +220,35 @@ export default function Chat() {
       <div style={styles.wrapper}>
         <h2 style={styles.titulo}>Hola, {nombre.split(" ")[0]} 👋</h2>
 
-        <div ref={chatRef} style={styles.chatBox}>
-          {historial.map((h, i) => (
-            <div key={i}>
-              <div
-                style={{
-                  ...styles.mensajeUsuario,
-                  backgroundColor:
-                    i % 2 === 0 ? colors.primario : colors.secundario,
-                }}
-              >
-                <p style={{ color: "#fff", margin: 0 }}>{h.mensaje}</p>
-              </div>
-              <div style={styles.mensajeBot}>
-                <div style={{ color: "#000" }}>
-                  <ReactMarkdown>{h.respuesta}</ReactMarkdown>
+        {historial.length === 0 ? (
+          <div style={styles.emptyContainer}>
+            <h3 style={styles.emptyTitulo}>¡Bienvenido a DomiChat!</h3>
+            <p style={styles.emptyTexto}>
+              Comienza escribiendo tu primera pregunta o mensaje.
+            </p>
+          </div>
+        ) : (
+          <div ref={chatRef} style={styles.chatBox}>
+            {historial.map((h, i) => (
+              <div key={i}>
+                <div
+                  style={{
+                    ...styles.mensajeUsuario,
+                    backgroundColor:
+                      i % 2 === 0 ? colors.primario : colors.secundario,
+                  }}
+                >
+                  <p style={{ color: "#fff", margin: 0 }}>{h.mensaje}</p>
+                </div>
+                <div style={styles.mensajeBot}>
+                  <div style={{ color: "#000" }}>
+                    <ReactMarkdown>{h.respuesta}</ReactMarkdown>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
 
         <div style={styles.inputBox}>
           <input

--- a/apps/web/pages/login.tsx
+++ b/apps/web/pages/login.tsx
@@ -33,8 +33,12 @@ export default function Login() {
 
       // Redirigir al chat
       router.push("/chat")
-    } catch (err: any) {
-      setError(err.response?.data?.error || "Error al iniciar sesión")
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.error || "Error al iniciar sesión")
+      } else {
+        setError("Error al iniciar sesión")
+      }
     } finally {
       setCargando(false)
     }

--- a/apps/web/pages/perfil.tsx
+++ b/apps/web/pages/perfil.tsx
@@ -15,7 +15,6 @@ export default function Perfil() {
   const router = useRouter()
   const [nombre, setNombre] = useState("")
   const [email, setEmail] = useState("")
-  const [token, setToken] = useState("")
   const [estado, setEstado] = useState<EstadoSuscripcion | null>(null)
   const { tema } = useContext(ThemeContext)
   const colors = temas[tema]
@@ -24,7 +23,6 @@ export default function Perfil() {
     const sesion = verificarSesion()
     if (!sesion) return
 
-    setToken(sesion.token)
     setNombre(sesion.nombre)
     if (sesion.email) setEmail(sesion.email)
 

--- a/apps/web/pages/registro.tsx
+++ b/apps/web/pages/registro.tsx
@@ -35,8 +35,12 @@ export default function Registro() {
       localStorage.setItem("email", data.email)
 
       router.push("/chat")
-    } catch (err: any) {
-      setError(err.response?.data?.error || "Error al registrarse")
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.error || "Error al registrarse")
+      } else {
+        setError("Error al registrarse")
+      }
     } finally {
       setCargando(false)
     }


### PR DESCRIPTION
## Summary
- align web chat empty state with mobile
- fix lint errors in login, perfil and registro pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847c66323188333b0f29f4b7aad832d