### PR TITLE
Fix input to bottom

### DIFF
--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -12,6 +12,11 @@ export default function Header() {
 
   const styles: { [key: string]: React.CSSProperties } = {
     header: {
+      position: "fixed",
+      top: 0,
+      left: 0,
+      right: 0,
+      zIndex: 1000,
       backgroundColor: colors.primario,
       borderBottom: `1px solid ${colors.primario}`,
       paddingLeft: 16,
@@ -21,6 +26,10 @@ export default function Header() {
       display: "flex",
       justifyContent: "space-between",
       alignItems: "center",
+      maxWidth: 800,
+      margin: "auto",
+      width: "100%",
+      boxSizing: "border-box",
     },
     left: {
       display: "flex",

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -113,7 +113,7 @@ export default function Chat() {
     wrapper: {
       maxWidth: 800,
       margin: "auto",
-      paddingTop: 30,
+      paddingTop: 70,
       paddingLeft: 16,
       paddingRight: 16,
       display: "flex",
@@ -130,7 +130,7 @@ export default function Chat() {
     chatBox: {
       flex: 1,
       overflowY: "auto",
-      paddingBottom: 20,
+      paddingBottom: 100,
     },
     card: {
       backgroundColor: colors.input,
@@ -169,8 +169,17 @@ export default function Chat() {
     inputBox: {
       display: "flex",
       gap: 8,
-      paddingTop: 10,
+      padding: "10px 16px",
       borderTop: `1px solid ${colors.borde}`,
+      position: "fixed",
+      bottom: 0,
+      left: 0,
+      right: 0,
+      backgroundColor: colors.fondo,
+      maxWidth: 800,
+      margin: "auto",
+      width: "100%",
+      boxSizing: "border-box",
     },
     input: {
       flex: 1,

--- a/apps/web/pages/configuracion.tsx
+++ b/apps/web/pages/configuracion.tsx
@@ -38,7 +38,7 @@ export default function Configuracion() {
     wrapper: {
       maxWidth: 500,
       margin: "auto",
-      paddingTop: 40,
+      paddingTop: 70,
       paddingLeft: 16,
       paddingRight: 16,
       backgroundColor: colors.fondo,

--- a/apps/web/pages/historial.tsx
+++ b/apps/web/pages/historial.tsx
@@ -32,7 +32,7 @@ export default function Historial() {
     wrapper: {
       maxWidth: 800,
       margin: "auto",
-      paddingTop: 30,
+      paddingTop: 70,
       paddingLeft: 16,
       paddingRight: 16,
       backgroundColor: colors.fondo,

--- a/apps/web/pages/perfil.tsx
+++ b/apps/web/pages/perfil.tsx
@@ -47,7 +47,7 @@ export default function Perfil() {
     wrapper: {
       maxWidth: 400,
       margin: "auto",
-      paddingTop: "12vh",
+      paddingTop: 70,
       paddingLeft: 16,
       paddingRight: 16,
       textAlign: "center",


### PR DESCRIPTION
## Summary
- position chat input fixed at bottom for web
- keep header fixed and adjust page padding for scrolling

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint errors in multiple files)*
- `npm run build` *(fails: Next.js build reports ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847c597d6988333b29690c77e8f8d61