### PR TITLE
Show full message history

### DIFF
--- a/apps/mobile/screens/ChatScreen.tsx
+++ b/apps/mobile/screens/ChatScreen.tsx
@@ -27,10 +27,13 @@ export default function ChatScreen({ route }: any) {
     nombre = "",
     mensajePrevio = "",
     respuestaPrevio = "",
+    mensajes = [],
   } = params
 
   const historialInicial =
-    mensajePrevio && respuestaPrevio
+    mensajes && mensajes.length > 0
+      ? mensajes
+      : mensajePrevio && respuestaPrevio
       ? [
           {
             mensaje: mensajePrevio,
@@ -50,16 +53,17 @@ export default function ChatScreen({ route }: any) {
   const colors = temas[tema]
 
   useEffect(() => {
-    if (!mensajePrevio && !respuestaPrevio && token) {
+    if (!mensajes.length && !mensajePrevio && !respuestaPrevio && token) {
       getHistorial(token)
-        .then((data) => setHistorial(data.historial || []))
+        .then((data) => setHistorial((data as any).historial || data))
         .catch(console.error)
     }
 
     AsyncStorage.getItem("voz_dominicana").then((voz) => {
       if (voz) setVozDominicana(voz)
     })
-  }, [historial])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const reproducirVoz = (texto: string) => {
     let opciones: Speech.SpeechOptions = {

--- a/apps/mobile/screens/HistorialScreen.tsx
+++ b/apps/mobile/screens/HistorialScreen.tsx
@@ -164,8 +164,7 @@ export default function HistorialScreen({ navigation }: any) {
                 const token = await AsyncStorage.getItem("token")
                 navigation.navigate(ROUTES.CHAT, {
                   token,
-                  mensajePrevio: item.mensajes[0]?.mensaje,
-                  respuestaPrevio: item.mensajes[0]?.respuesta,
+                  mensajes: item.mensajes,
                 })
               }}
             >

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -15,14 +15,21 @@ interface Mensaje {
 
 export default function Chat() {
   const router = useRouter()
-  const { mensajePrevio = "", respuestaPrevio = "" } = router.query as {
+  const {
+    mensajePrevio = "",
+    respuestaPrevio = "",
+    historial: historialQuery = "",
+  } = router.query as {
     mensajePrevio?: string
     respuestaPrevio?: string
+    historial?: string
   }
 
   const historialInicial:
     | Mensaje[]
-    | (() => Mensaje[]) = mensajePrevio && respuestaPrevio
+    | (() => Mensaje[]) = historialQuery
+    ? JSON.parse(decodeURIComponent(historialQuery as string))
+    : mensajePrevio && respuestaPrevio
     ? [
         {
           mensaje: decodeURIComponent(mensajePrevio as string),
@@ -48,7 +55,7 @@ export default function Chat() {
     setToken(sesion.token)
     setNombre(sesion.nombre)
 
-    if (!mensajePrevio && !respuestaPrevio) {
+    if (!historialQuery && !mensajePrevio && !respuestaPrevio) {
       axios
         .get("http://localhost:4000/api/chat/historial", {
           headers: { Authorization: `Bearer ${sesion.token}` },
@@ -57,7 +64,7 @@ export default function Chat() {
         .catch(() => {})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mensajePrevio, respuestaPrevio])
+  }, [historialQuery, mensajePrevio, respuestaPrevio])
 
   function modificarRespuestaSegunVoz(texto: string, voz: string): string {
     switch (voz) {

--- a/apps/web/pages/historial.tsx
+++ b/apps/web/pages/historial.tsx
@@ -38,12 +38,10 @@ export default function Historial() {
   }, [])
 
   const abrirChat = (item: HistItem) => {
-    const primero = item.mensajes[0]
     router.push({
       pathname: "/chat",
       query: {
-        mensajePrevio: primero?.mensaje || "",
-        respuestaPrevio: primero?.respuesta || "",
+        historial: encodeURIComponent(JSON.stringify(item.mensajes)),
       },
     })
   }


### PR DESCRIPTION
## Summary
- show entire message list when opening a history item on web
- handle full history payload in web chat page
- send full message list from mobile history screen
- load provided messages in mobile chat screen

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ca6846a08333ae656544d7423959