### PR TITLE
Improve chat flow persistence

### DIFF
--- a/apps/mobile/components/Header.tsx
+++ b/apps/mobile/components/Header.tsx
@@ -1,10 +1,17 @@
 import React, { useContext } from "react"
-import { View, Text, StyleSheet } from "react-native"
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native"
+import { Ionicons } from "@expo/vector-icons"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
 
-export default function Header({ titulo }: { titulo: string }) {
+export default function Header({
+  titulo,
+  onNewChat,
+}: {
+  titulo: string
+  onNewChat?: () => void
+}) {
   const { tema } = useContext(ThemeContext)
   const colors = temas[tema]
 
@@ -17,6 +24,11 @@ export default function Header({ titulo }: { titulo: string }) {
         ]}
       >
         <Text style={[styles.titulo, { color: "#fff" }]}>{titulo}</Text>
+        {onNewChat && (
+          <TouchableOpacity onPress={onNewChat} style={styles.action}>
+            <Ionicons name="add-circle-outline" size={24} color="#fff" />
+          </TouchableOpacity>
+        )}
       </View>
     </SafeAreaView>
   )
@@ -25,12 +37,16 @@ export default function Header({ titulo }: { titulo: string }) {
 const styles = StyleSheet.create({
   container: {
     height: 56,
+    flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
+    justifyContent: "space-between",
     borderBottomWidth: 1,
   },
   titulo: {
     fontSize: 18,
     fontWeight: "bold",
+  },
+  action: {
+    paddingHorizontal: 12,
   },
 })

--- a/apps/web/services/chat.ts
+++ b/apps/web/services/chat.ts
@@ -1,0 +1,23 @@
+import axios from "axios"
+
+export interface ChatMensaje {
+  mensaje: string
+  respuesta: string
+  creadoEn: string
+}
+
+export function generarTitulo(mensajes: { rol: string; texto: string }[]): string {
+  const primer = mensajes.find((m) => m.rol === "usuario")?.texto || "Chat sin título"
+  return primer.length < 30 ? primer : primer.slice(0, 30) + "..."
+}
+
+export async function guardarHistorial(
+  token: string,
+  mensajes: ChatMensaje[]
+) {
+  const titulo = generarTitulo(mensajes.map((m) => ({ rol: "usuario", texto: m.mensaje })))
+  const data = { titulo, fecha: new Date().toISOString(), mensajes }
+  await axios.post("http://localhost:4000/api/chat/historial", data, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}


### PR DESCRIPTION
## Summary
- store active chat in `localStorage`/`AsyncStorage` to persist between pages
- add `Nuevo chat` button next to greeting in web and mobile
- save current chat to history when starting a new chat
- support new chat action in mobile header

## Testing
- `npm run lint` within `apps/web`
- `npx tsc --noEmit` within `apps/mobile` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847d1e7e270833398759c11620a9877