### PR TITLE
Implement new sidebar layout

### DIFF
--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link"
+import { useRouter } from "next/router"
+import { useContext, useEffect, useState } from "react"
+import { ThemeContext } from "../context/ThemeContext"
+import { temas } from "../constants/colors"
+
+export default function Sidebar() {
+  const router = useRouter()
+  const [nombre, setNombre] = useState("")
+  const { tema } = useContext(ThemeContext)
+  const colors = temas[tema]
+
+  useEffect(() => {
+    const n = localStorage.getItem("nombre")
+    if (n) setNombre(n)
+  }, [])
+
+  const cerrarSesion = () => {
+    localStorage.removeItem("token")
+    localStorage.removeItem("nombre")
+    router.push("/login")
+  }
+
+  const styles: { [key: string]: React.CSSProperties } = {
+    sidebar: {
+      position: "fixed",
+      top: 0,
+      bottom: 0,
+      left: 0,
+      width: 220,
+      backgroundColor: colors.primario,
+      color: "#fff",
+      padding: 16,
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      boxSizing: "border-box",
+    },
+    nav: {
+      display: "flex",
+      flexDirection: "column",
+      gap: 12,
+    },
+    link: {
+      color: "#fff",
+      textDecoration: "none",
+      fontWeight: 600,
+      padding: "8px 12px",
+      borderRadius: 6,
+    },
+    bottom: {
+      display: "flex",
+      flexDirection: "column",
+      gap: 12,
+    },
+    nombre: {
+      color: "#fff",
+      fontSize: 14,
+    },
+    boton: {
+      backgroundColor: colors.secundario,
+      color: "#fff",
+      border: "none",
+      borderRadius: 6,
+      padding: "8px 12px",
+      fontWeight: 600,
+      cursor: "pointer",
+    },
+  }
+
+  return (
+    <aside style={styles.sidebar}>
+      <nav style={styles.nav}>
+        <Link href="/chat" style={styles.link}>
+          Nuevo chat
+        </Link>
+        <Link href="/historial" style={styles.link}>
+          Historial
+        </Link>
+        <Link href="/perfil" style={styles.link}>
+          Perfil
+        </Link>
+        <Link href="/configuracion" style={styles.link}>
+          Configuración
+        </Link>
+      </nav>
+      <div style={styles.bottom}>
+        <span style={styles.nombre}>{nombre}</span>
+        <button onClick={cerrarSesion} style={styles.boton}>
+          Cerrar sesión
+        </button>
+      </div>
+    </aside>
+  )
+}

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,13 +1,15 @@
 import type { AppProps } from "next/app"
 import { ThemeProvider } from "../context/ThemeContext"
 import "../styles/globals.css"
-import Header from "@/components/Header"
+import Sidebar from "@/components/Sidebar"
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
-      <Header />
-      <Component {...pageProps} />
+      <Sidebar />
+      <div style={{ marginLeft: 220 }}>
+        <Component {...pageProps} />
+      </div>
     </ThemeProvider>
   )
 }

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "next/router"
 import axios from "axios"
 import { temas } from "../constants/colors"
 import { verificarSesion } from "../services/auth"
-import Header from "../components/Header"
 import { ThemeContext } from "../context/ThemeContext"
 import ReactMarkdown from "react-markdown"
 import { guardarHistorial } from "../services/chat"
@@ -165,7 +164,7 @@ export default function Chat() {
     wrapper: {
       maxWidth: 800,
       margin: "auto",
-      paddingTop: 70,
+      paddingTop: 24,
       paddingLeft: 16,
       paddingRight: 16,
       display: "flex",
@@ -244,7 +243,7 @@ export default function Chat() {
       borderTop: `1px solid ${colors.borde}`,
       position: "fixed",
       bottom: 0,
-      left: 0,
+      left: 220,
       right: 0,
       backgroundColor: colors.fondo,
       maxWidth: 800,

--- a/apps/web/pages/configuracion.tsx
+++ b/apps/web/pages/configuracion.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useContext } from "react"
-import Header from "@/components/Header"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
 
@@ -38,7 +37,7 @@ export default function Configuracion() {
     wrapper: {
       maxWidth: 500,
       margin: "auto",
-      paddingTop: 70,
+      paddingTop: 24,
       paddingLeft: 16,
       paddingRight: 16,
       backgroundColor: colors.fondo,

--- a/apps/web/pages/historial.tsx
+++ b/apps/web/pages/historial.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useContext } from "react"
 import { useRouter } from "next/router"
 import axios from "axios"
-import Header from "../components/Header"
 import { temas } from "../constants/colors"
 import { verificarSesion } from "../services/auth"
 import { ThemeContext } from "../context/ThemeContext"
@@ -105,7 +104,7 @@ export default function Historial() {
     wrapper: {
       maxWidth: 800,
       margin: "auto",
-      paddingTop: 70,
+      paddingTop: 24,
       paddingLeft: 16,
       paddingRight: 16,
       backgroundColor: colors.fondo,

--- a/apps/web/pages/perfil.tsx
+++ b/apps/web/pages/perfil.tsx
@@ -3,7 +3,6 @@ import axios from "axios"
 import { useRouter } from "next/router"
 import { verificarSesion } from "../services/auth"
 import { temas } from "../constants/colors"
-import Header from "@/components/Header"
 import { ThemeContext } from "../context/ThemeContext"
 
 interface EstadoSuscripcion {
@@ -45,7 +44,7 @@ export default function Perfil() {
     wrapper: {
       maxWidth: 400,
       margin: "auto",
-      paddingTop: 70,
+      paddingTop: 24,
       paddingLeft: 16,
       paddingRight: 16,
       textAlign: "center",


### PR DESCRIPTION
## Summary
- add Sidebar component with navigation and logout
- replace old header with Sidebar in `_app.tsx`
- tweak chat page layout for Sidebar
- adjust top padding in historial/perfil/configuracion pages

## Testing
- `npm run lint` in `apps/web`
- `npx tsc --noEmit` in `apps/web`

------
https://chatgpt.com/codex/tasks/task_e_6849b2d26a348333a3c6861b87449330