### PR TITLE
Add icons across web and mobile

### DIFF
--- a/apps/mobile/screens/ConfiguracionScreen.tsx
+++ b/apps/mobile/screens/ConfiguracionScreen.tsx
@@ -10,6 +10,7 @@ import {
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
+import { Ionicons } from "@expo/vector-icons"
 
 const VOCES = [
   { id: "popi", nombre: "Voz Popi (Distrito Nacional)" },
@@ -86,7 +87,9 @@ export default function ConfiguracionScreen() {
         style={[styles.botonReset, { backgroundColor: colors.gris }]}
         onPress={restaurarValores}
       >
-        <Text style={styles.textoReset}>Restaurar valores por defecto</Text>
+        <Text style={styles.textoReset}>
+          <Ionicons name="refresh-outline" size={20} color="#fff" /> Restaurar valores por defecto
+        </Text>
       </TouchableOpacity>
 
       <TouchableOpacity
@@ -99,6 +102,19 @@ export default function ConfiguracionScreen() {
         <Text
           style={[styles.textoTema, { color: temaOscuro ? "#000" : "#fff" }]}
         >
+          {temaOscuro ? (
+            <Ionicons
+              name="sunny-outline"
+              size={20}
+              color={temaOscuro ? "#000" : "#fff"}
+            />
+          ) : (
+            <Ionicons
+              name="moon-outline"
+              size={20}
+              color={temaOscuro ? "#000" : "#fff"}
+            />
+          )}{" "}
           Usar tema {temaOscuro ? "claro" : "oscuro"}
         </Text>
       </TouchableOpacity>

--- a/apps/mobile/screens/HistorialScreen.tsx
+++ b/apps/mobile/screens/HistorialScreen.tsx
@@ -212,7 +212,9 @@ export default function HistorialScreen({ navigation }: any) {
             style={[styles.botonReset, { backgroundColor: colors.secundario }]}
             onPress={eliminarTodoElHistorial}
           >
-            <Text style={styles.textoBoton}>Eliminar todo el historial</Text>
+            <Text style={styles.textoBoton}>
+              <Ionicons name="trash-outline" size={20} color="#fff" /> Eliminar todo el historial
+            </Text>
           </TouchableOpacity>
         }
       />

--- a/apps/mobile/screens/LoginScreen.tsx
+++ b/apps/mobile/screens/LoginScreen.tsx
@@ -15,6 +15,7 @@ import { ROUTES } from "../constants/routes"
 import { useGoogleLogin, loginWithApple } from "../services/authSocial"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import { Ionicons } from "@expo/vector-icons"
 
 export default function LoginScreen({ navigation }: any) {
   const { tema } = useContext(ThemeContext)
@@ -96,7 +97,9 @@ export default function LoginScreen({ navigation }: any) {
           onPress={iniciarSesion}
           disabled={cargando}
         >
-          <Text style={styles.botonTexto}>Entrar</Text>
+          <Text style={styles.botonTexto}>
+            Entrar <Ionicons name="log-in-outline" size={20} color="#fff" />
+          </Text>
         </TouchableOpacity>
 
         <TouchableOpacity

--- a/apps/mobile/screens/PerfilScreen.tsx
+++ b/apps/mobile/screens/PerfilScreen.tsx
@@ -14,6 +14,7 @@ import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
 import { useNavigation } from "@react-navigation/native"
 import Header from "../components/Header"
+import { Ionicons } from "@expo/vector-icons"
 
 export default function PerfilScreen({ route, navigation }: any) {
   const [nombre, setNombre] = useState("")
@@ -117,14 +118,18 @@ export default function PerfilScreen({ route, navigation }: any) {
             ]}
             onPress={() => navigation.navigate("Configuracion")}
           >
-            <Text style={styles.botonTexto}>Configuración de DomiChat</Text>
+            <Text style={styles.botonTexto}>
+              <Ionicons name="settings-outline" size={20} color="#fff" /> Configuración de DomiChat
+            </Text>
           </TouchableOpacity>
 
           <TouchableOpacity
             style={[styles.botonCerrar, { backgroundColor: colors.peligro }]}
             onPress={cerrarSesion}
           >
-            <Text style={styles.botonTexto}>Cerrar sesión</Text>
+            <Text style={styles.botonTexto}>
+              <Ionicons name="log-out-outline" size={20} color="#fff" /> Cerrar sesión
+            </Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/apps/mobile/screens/RegisterScreen.tsx
+++ b/apps/mobile/screens/RegisterScreen.tsx
@@ -14,6 +14,7 @@ import { ROUTES } from "../constants/routes"
 import { registrarUsuario } from "../services/api"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import { Ionicons } from "@expo/vector-icons"
 
 export default function RegisterScreen({ navigation }: any) {
   const { tema } = useContext(ThemeContext)
@@ -95,7 +96,9 @@ export default function RegisterScreen({ navigation }: any) {
           onPress={registrar}
           disabled={cargando}
         >
-          <Text style={styles.botonTexto}>Registrarse</Text>
+          <Text style={styles.botonTexto}>
+            Registrarse <Ionicons name="person-add-outline" size={20} color="#fff" />
+          </Text>
         </TouchableOpacity>
 
         <TouchableOpacity onPress={() => navigation.navigate(ROUTES.LOGIN)}>

--- a/apps/mobile/screens/WelcomeScreen.tsx
+++ b/apps/mobile/screens/WelcomeScreen.tsx
@@ -12,6 +12,7 @@ import { useNavigation } from "@react-navigation/native"
 import { ROUTES } from "../constants/routes"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import { Ionicons } from "@expo/vector-icons"
 
 export default function WelcomeScreen({ navigation }: any) {
   const [loading, setLoading] = useState(true)
@@ -61,7 +62,9 @@ export default function WelcomeScreen({ navigation }: any) {
         onPress={continuar}
         style={[styles.boton, { backgroundColor: colors.primario }]}
       >
-        <Text style={styles.botonTexto}>Empezar</Text>
+        <Text style={styles.botonTexto}>
+          Empezar <Ionicons name="arrow-forward" size={20} color="#fff" />
+        </Text>
       </TouchableOpacity>
     </View>
   )

--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -3,6 +3,13 @@ import { useEffect, useState, useContext } from "react"
 import { useRouter } from "next/router"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
+import {
+  IoChatbubbleEllipsesOutline,
+  IoTimeOutline,
+  IoPersonCircleOutline,
+  IoSettingsOutline,
+  IoLogOutOutline,
+} from "react-icons/io5"
 
 export default function Header() {
   const router = useRouter()
@@ -74,15 +81,19 @@ export default function Header() {
     <header style={styles.header}>
       <div style={styles.left}>
         <Link href="/chat" style={styles.link}>
+          <IoChatbubbleEllipsesOutline style={{ marginRight: 4 }} />
           Chat
         </Link>
         <Link href="/historial" style={styles.link}>
+          <IoTimeOutline style={{ marginRight: 4 }} />
           Historial
         </Link>
         <Link href="/perfil" style={styles.link}>
+          <IoPersonCircleOutline style={{ marginRight: 4 }} />
           Perfil
         </Link>
         <Link href="/configuracion" style={styles.link}>
+          <IoSettingsOutline style={{ marginRight: 4 }} />
           Configuración
         </Link>
       </div>
@@ -90,7 +101,7 @@ export default function Header() {
       <div style={styles.right}>
         <span style={styles.nombre}>{nombre}</span>
         <button onClick={cerrarSesion} style={styles.boton}>
-          Cerrar sesión
+          <IoLogOutOutline style={{ marginRight: 6 }} /> Cerrar sesión
         </button>
       </div>
     </header>

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -3,6 +3,13 @@ import { useRouter } from "next/router"
 import { useContext, useEffect, useState } from "react"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import {
+  IoChatbubbleEllipsesOutline,
+  IoTimeOutline,
+  IoPersonCircleOutline,
+  IoSettingsOutline,
+  IoLogOutOutline,
+} from "react-icons/io5"
 
 export default function Sidebar() {
   const router = useRouter()
@@ -72,22 +79,22 @@ export default function Sidebar() {
     <aside style={styles.sidebar}>
       <nav style={styles.nav}>
         <Link href="/chat" style={styles.link}>
-          Nuevo chat
+          <IoChatbubbleEllipsesOutline style={{ marginRight: 6 }} /> Nuevo chat
         </Link>
         <Link href="/historial" style={styles.link}>
-          Historial
+          <IoTimeOutline style={{ marginRight: 6 }} /> Historial
         </Link>
         <Link href="/perfil" style={styles.link}>
-          Perfil
+          <IoPersonCircleOutline style={{ marginRight: 6 }} /> Perfil
         </Link>
         <Link href="/configuracion" style={styles.link}>
-          Configuración
+          <IoSettingsOutline style={{ marginRight: 6 }} /> Configuración
         </Link>
       </nav>
       <div style={styles.bottom}>
         <span style={styles.nombre}>{nombre}</span>
         <button onClick={cerrarSesion} style={styles.boton}>
-          Cerrar sesión
+          <IoLogOutOutline style={{ marginRight: 6 }} /> Cerrar sesión
         </button>
       </div>
     </aside>

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.56.1",
+        "react-icons": "^4.12.0",
         "react-markdown": "^9.1.0"
       },
       "devDependencies": {
@@ -5276,6 +5277,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.1",
+    "react-icons": "^4.12.0",
     "react-markdown": "^9.1.0"
   },
   "devDependencies": {

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -6,6 +6,7 @@ import { verificarSesion } from "../services/auth"
 import { ThemeContext } from "../context/ThemeContext"
 import ReactMarkdown from "react-markdown"
 import { guardarHistorial } from "../services/chat"
+import { IoAddCircleOutline, IoSend } from "react-icons/io5"
 
 interface Mensaje {
   mensaje: string
@@ -299,7 +300,7 @@ export default function Chat() {
         <div style={styles.tituloRow}>
           <h2 style={styles.titulo}>Hola, {nombre.split(" ")[0]} 👋</h2>
           <button onClick={nuevoChat} style={styles.botonNuevo}>
-            Nuevo chat
+            <IoAddCircleOutline style={{ marginRight: 6 }} /> Nuevo chat
           </button>
         </div>
 
@@ -342,7 +343,13 @@ export default function Chat() {
             style={styles.input}
           />
           <button onClick={enviarMensaje} style={styles.boton}>
-            {cargando ? "..." : "Enviar"}
+            {cargando ? (
+              "..."
+            ) : (
+              <>
+                <IoSend style={{ marginRight: 4 }} /> Enviar
+              </>
+            )}
           </button>
         </div>
       </div>

--- a/apps/web/pages/configuracion.tsx
+++ b/apps/web/pages/configuracion.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, useContext } from "react"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
+import {
+  IoRefreshOutline,
+  IoSunnyOutline,
+  IoMoonOutline,
+} from "react-icons/io5"
 
 const VOCES = [
   { id: "popi", nombre: "Voz Popi (Distrito Nacional)" },
@@ -101,13 +106,18 @@ export default function Configuracion() {
             </button>
           ))}
           <button onClick={restaurarVoz} style={styles.botonSecundario}>
-            Restaurar voz por defecto
+            <IoRefreshOutline style={{ marginRight: 4 }} /> Restaurar voz por defecto
           </button>
         </div>
 
         <div style={styles.seccion}>
           <h3 style={styles.subtitulo}>Tema</h3>
           <button onClick={cambiarTema} style={styles.botonSecundario}>
+            {tema === "oscuro" ? (
+              <IoSunnyOutline style={{ marginRight: 4 }} />
+            ) : (
+              <IoMoonOutline style={{ marginRight: 4 }} />
+            )}
             Usar tema {tema === "oscuro" ? "claro" : "oscuro"}
           </button>
         </div>

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 import Image from "next/image"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import { IoArrowForwardOutline } from "react-icons/io5"
 
 export default function Home() {
   const router = useRouter()
@@ -74,7 +75,7 @@ export default function Home() {
         Tu asistente dominicano 🇩🇴 donde y cuando lo necesites
       </p>
       <button onClick={continuar} style={styles.boton}>
-        Empezar
+        Empezar <IoArrowForwardOutline style={{ marginLeft: 6 }} />
       </button>
     </div>
   )

--- a/apps/web/pages/login.tsx
+++ b/apps/web/pages/login.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 import { useState, useContext } from "react"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
+import { IoLogInOutline } from "react-icons/io5"
 
 interface FormValues {
   email: string
@@ -118,7 +119,13 @@ export default function Login() {
         />
 
         <button type="submit" style={styles.boton}>
-          {cargando ? "Entrando..." : "Entrar"}
+          {cargando ? (
+            "Entrando..."
+          ) : (
+            <>
+              <IoLogInOutline style={{ marginRight: 4 }} /> Entrar
+            </>
+          )}
         </button>
       </form>
 

--- a/apps/web/pages/registro.tsx
+++ b/apps/web/pages/registro.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router"
 import { useState, useContext } from "react"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
+import { IoPersonAddOutline } from "react-icons/io5"
 
 interface FormValues {
   nombre: string
@@ -127,7 +128,13 @@ export default function Registro() {
         />
 
         <button type="submit" style={styles.boton}>
-          {cargando ? "Registrando..." : "Registrarse"}
+          {cargando ? (
+            "Registrando..."
+          ) : (
+            <>
+              <IoPersonAddOutline style={{ marginRight: 4 }} /> Registrarse
+            </>
+          )}
         </button>
       </form>
 


### PR DESCRIPTION
## Summary
- install `react-icons` for the web app
- show Ionicons in web header, sidebar and pages
- add Ionicons to mobile screens for consistent look

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849b5c918e88333ab4c0b7ccd5a5889