### PR TITLE
Add new Domichat logo across web app

### DIFF
--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router"
 import { useContext, useEffect, useState } from "react"
 import { ThemeContext } from "../context/ThemeContext"
 import { temas } from "../constants/colors"
+import Image from "next/image"
 import {
   IoChatbubbleEllipsesOutline,
   IoTimeOutline,
@@ -55,6 +56,10 @@ export default function Sidebar() {
       padding: "8px 12px",
       borderRadius: 6,
     },
+    logo: {
+      display: "block",
+      margin: "0 auto 20px",
+    },
     bottom: {
       display: "flex",
       flexDirection: "column",
@@ -77,6 +82,13 @@ export default function Sidebar() {
 
   return (
     <aside style={styles.sidebar}>
+      <Image
+        src="/domichat-logo.svg"
+        width={120}
+        height={120}
+        alt="DomiChat logo"
+        style={styles.logo}
+      />
       <nav style={styles.nav}>
         <Link href="/chat" style={styles.link}>
           <IoChatbubbleEllipsesOutline

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -69,7 +69,7 @@ export default function Home() {
 
   return (
     <div style={styles.container}>
-      <Image src="/logo.png" width={160} height={160} alt="DomiChat logo" />
+      <Image src="/domichat-logo.svg" width={160} height={160} alt="DomiChat logo" />
       <h1 style={styles.titulo}>Bienvenido a DomiChat</h1>
       <p style={styles.subtitulo}>
         Tu asistente dominicano 🇩🇴 donde y cuando lo necesites

--- a/apps/web/pages/login.tsx
+++ b/apps/web/pages/login.tsx
@@ -5,6 +5,7 @@ import { useState, useContext } from "react"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
 import { IoLogInOutline } from "react-icons/io5"
+import Image from "next/image"
 
 interface FormValues {
   email: string
@@ -100,6 +101,13 @@ export default function Login() {
 
   return (
     <div style={styles.wrapper}>
+      <Image
+        src="/domichat-logo.svg"
+        width={120}
+        height={120}
+        alt="DomiChat logo"
+        style={{ display: "block", margin: "0 auto 20px" }}
+      />
       <h2 style={styles.titulo}>Iniciar sesión</h2>
 
       <form onSubmit={handleSubmit(onSubmit)} style={styles.form}>

--- a/apps/web/pages/registro.tsx
+++ b/apps/web/pages/registro.tsx
@@ -5,6 +5,7 @@ import { useState, useContext } from "react"
 import { temas } from "../constants/colors"
 import { ThemeContext } from "../context/ThemeContext"
 import { IoPersonAddOutline } from "react-icons/io5"
+import Image from "next/image"
 
 interface FormValues {
   nombre: string
@@ -102,6 +103,13 @@ export default function Registro() {
 
   return (
     <div style={styles.wrapper}>
+      <Image
+        src="/domichat-logo.svg"
+        width={120}
+        height={120}
+        alt="DomiChat logo"
+        style={{ display: "block", margin: "0 auto 20px" }}
+      />
       <h2 style={styles.titulo}>Crear cuenta</h2>
 
       <form onSubmit={handleSubmit(onSubmit)} style={styles.form}>


### PR DESCRIPTION
## Summary
- use `domichat-logo.svg` on the home page
- show the logo on login and registration screens
- display the logo in the sidebar navigation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849c1c289c483338a5a664f2b8c6525