### PR TITLE
Fix sidebar behaviour on resize

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -13,7 +13,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     const handleResize = () => {
       const mobile = window.innerWidth < 768
       setIsMobile(mobile)
-      if (!mobile) setSidebarOpen(true)
+      if (mobile) {
+        setSidebarOpen(false)
+      } else {
+        setSidebarOpen(true)
+      }
     }
     handleResize()
     window.addEventListener("resize", handleResize)

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -192,6 +192,7 @@ export default function Chat() {
       alignItems: "center",
       justifyContent: "space-between",
       marginBottom: 20,
+      paddingLeft: isMobile ? 40 : 0,
     },
     botonNuevo: {
       backgroundColor: colors.secundario,


### PR DESCRIPTION
## Summary
- close sidebar when resizing to mobile
- shift chat title to avoid overlap with hamburger menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849c921d1a083338b4f38e4abc4e44b