### PR TITLE
Fix sidebar visibility when logged out

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -3,11 +3,14 @@ import { ThemeProvider } from "../context/ThemeContext"
 import "../styles/globals.css"
 import Sidebar from "@/components/Sidebar"
 import { useEffect, useState } from "react"
+import { useRouter } from "next/router"
 import { IoMenuOutline } from "react-icons/io5"
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [isMobile, setIsMobile] = useState(true)
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const router = useRouter()
 
   useEffect(() => {
     const handleResize = () => {
@@ -24,31 +27,40 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     return () => window.removeEventListener("resize", handleResize)
   }, [])
 
+  useEffect(() => {
+    const token = localStorage.getItem("token")
+    setIsLoggedIn(!!token)
+  }, [router.pathname])
+
   const toggleSidebar = () => setSidebarOpen((o) => !o)
 
   return (
     <ThemeProvider>
-      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-      <button
-        onClick={toggleSidebar}
-        style={{
-          position: "fixed",
-          top: 26,
-          left: 16,
-          background: "none",
-          border: "none",
-          color: "inherit",
-          fontSize: 28,
-          zIndex: 1100,
-          display: isMobile ? "block" : "none",
-          cursor: "pointer",
-        }}
-      >
-        <IoMenuOutline color={sidebarOpen ? "#fff" : "#000"} />
-      </button>
+      {isLoggedIn && (
+        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      )}
+      {isLoggedIn && (
+        <button
+          onClick={toggleSidebar}
+          style={{
+            position: "fixed",
+            top: 26,
+            left: 16,
+            background: "none",
+            border: "none",
+            color: "inherit",
+            fontSize: 28,
+            zIndex: 1100,
+            display: isMobile ? "block" : "none",
+            cursor: "pointer",
+          }}
+        >
+          <IoMenuOutline color={sidebarOpen ? "#fff" : "#000"} />
+        </button>
+      )}
       <div
         style={{
-          marginLeft: isMobile ? 0 : 220,
+          marginLeft: isLoggedIn && !isMobile ? 220 : 0,
           transition: "margin-left 0.3s ease-in-out",
         }}
       >


### PR DESCRIPTION
## Summary
- show sidebar and menu button only when logged in

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849df081c388333a75827c4a7f71425