### PR TITLE
Add loading states to chat messages

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -42,3 +42,36 @@ a {
     color-scheme: dark;
   }
 }
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  border: 2px solid #f3f3f3;
+  border-top: 2px solid var(--primario);
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.4s ease-out;
+}


### PR DESCRIPTION
## Summary
- show placeholder message while waiting for chatbot response
- replace placeholders when SSE message arrives
- add spinner animation and fade in effect
- display spinner in send button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849e1d856148333a13df3c1a5990b41