### PR TITLE
Use env variable for API base URL

### DIFF
--- a/apps/mobile/constants/config.ts
+++ b/apps/mobile/constants/config.ts
@@ -4,10 +4,10 @@ const ENV = "dev" // Cambia a 'prod' cuando publiques
 
 const config = {
   dev: {
-    BASE_URL: "http://10.0.0.9:4000/api", // tu IP local
+    BASE_URL: process.env.NEXT_PUBLIC_API_URL || "http://10.0.0.9:4000/api", // tu IP local
   },
   prod: {
-    BASE_URL: "https://tu-dominio.com/api", // o ngrok temporal
+    BASE_URL: process.env.NEXT_PUBLIC_API_URL || "https://tu-dominio.com/api", // o ngrok temporal
   },
 }
 

--- a/apps/web/pages/chat.tsx
+++ b/apps/web/pages/chat.tsx
@@ -64,14 +64,14 @@ export default function Chat() {
 
     if (!historialQuery && !mensajePrevio && !respuestaPrevio) {
       axios
-        .get("http://localhost:4000/api/chat/activo", {
+        .get(`${process.env.NEXT_PUBLIC_API_URL}/chat/activo`, {
           headers: { Authorization: `Bearer ${sesion.token}` },
         })
         .then((r) => setHistorial(r.data))
         .catch(() => {})
 
       const ev = new EventSource(
-        `http://localhost:4000/api/chat/stream?token=${sesion.token}`
+        `${process.env.NEXT_PUBLIC_API_URL}/chat/stream?token=${sesion.token}`
       )
       ev.onmessage = (e) => {
         const data = JSON.parse(e.data)
@@ -151,7 +151,7 @@ export default function Chat() {
     setCargando(true)
     try {
       const res = await axios.post(
-        "http://localhost:4000/api/chat",
+        `${process.env.NEXT_PUBLIC_API_URL}/chat`,
         { mensaje: mensajeActual },
         { headers: { Authorization: `Bearer ${token}` } }
       )

--- a/apps/web/pages/dataset.tsx
+++ b/apps/web/pages/dataset.tsx
@@ -18,7 +18,7 @@ export default function DatasetForm() {
   const agregarEntrada = async () => {
     if (!pregunta || !respuesta) return
 
-    await axios.post("http://localhost:4000/api/dataset/agregar", {
+    await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/dataset/agregar`, {
       pregunta,
       respuesta,
     })

--- a/apps/web/pages/dataset/ver.tsx
+++ b/apps/web/pages/dataset/ver.tsx
@@ -15,7 +15,7 @@ export default function VerDataset() {
 
   useEffect(() => {
     axios
-      .get("http://localhost:4000/api/dataset/listar")
+      .get(`${process.env.NEXT_PUBLIC_API_URL}/dataset/listar`)
       .then((res) => setEntradas(res.data))
       .catch(() => {})
   }, [])

--- a/apps/web/pages/historial.tsx
+++ b/apps/web/pages/historial.tsx
@@ -38,7 +38,7 @@ export default function Historial() {
     if (!sesion) return
 
     axios
-      .get("http://localhost:4000/api/chat/historial", {
+      .get(`${process.env.NEXT_PUBLIC_API_URL}/chat/historial`, {
         headers: { Authorization: `Bearer ${sesion.token}` },
       })
       .then((res) => setItems(res.data))
@@ -63,7 +63,7 @@ export default function Historial() {
       if (!sesion) return
 
       await axios.put(
-        `http://localhost:4000/api/chat/historial/${item.id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/chat/historial/${item.id}`,
         { nuevoTitulo: nuevo },
         { headers: { Authorization: `Bearer ${sesion.token}` } }
       )
@@ -83,9 +83,12 @@ export default function Historial() {
       const sesion = verificarSesion()
       if (!sesion) return
 
-      await axios.delete(`http://localhost:4000/api/chat/historial/${id}`, {
-        headers: { Authorization: `Bearer ${sesion.token}` },
-      })
+      await axios.delete(
+        `${process.env.NEXT_PUBLIC_API_URL}/chat/historial/${id}`,
+        {
+          headers: { Authorization: `Bearer ${sesion.token}` },
+        }
+      )
 
       setItems((prev) => prev.filter((i) => i.id !== id))
     } catch (err) {
@@ -100,9 +103,12 @@ export default function Historial() {
       const sesion = verificarSesion()
       if (!sesion) return
 
-      await axios.delete("http://localhost:4000/api/chat/historial/todo", {
-        headers: { Authorization: `Bearer ${sesion.token}` },
-      })
+      await axios.delete(
+        `${process.env.NEXT_PUBLIC_API_URL}/chat/historial/todo`,
+        {
+          headers: { Authorization: `Bearer ${sesion.token}` },
+        }
+      )
       setItems([])
     } catch (err) {
       console.error(err)

--- a/apps/web/pages/login.tsx
+++ b/apps/web/pages/login.tsx
@@ -25,7 +25,10 @@ export default function Login() {
     setCargando(true)
 
     try {
-      const res = await axios.post("http://localhost:4000/api/auth/login", data) // Reemplaza si usas ngrok
+      const res = await axios.post(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/login`,
+        data
+      ) // Reemplaza si usas ngrok
       const { token, usuario } = res.data
 
       // Guardar en localStorage

--- a/apps/web/pages/perfil.tsx
+++ b/apps/web/pages/perfil.tsx
@@ -26,7 +26,7 @@ export default function Perfil() {
     if (sesion.email) setEmail(sesion.email)
 
     axios
-      .get("http://localhost:4000/api/subscription/estado", {
+      .get(`${process.env.NEXT_PUBLIC_API_URL}/subscription/estado`, {
         headers: { Authorization: `Bearer ${sesion.token}` },
       })
       .then((res) => setEstado(res.data))

--- a/apps/web/pages/registro.tsx
+++ b/apps/web/pages/registro.tsx
@@ -27,7 +27,7 @@ export default function Registro() {
 
     try {
       const res = await axios.post(
-        "http://localhost:4000/api/auth/registro",
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/registro`,
         data
       )
       const { token, usuario } = res.data

--- a/apps/web/services/chat.ts
+++ b/apps/web/services/chat.ts
@@ -17,7 +17,11 @@ export async function guardarHistorial(
 ) {
   const titulo = generarTitulo(mensajes.map((m) => ({ rol: "usuario", texto: m.mensaje })))
   const data = { titulo, fecha: new Date().toISOString(), mensajes }
-  await axios.post("http://localhost:4000/api/chat/historial", data, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
+  await axios.post(
+    `${process.env.NEXT_PUBLIC_API_URL}/chat/historial`,
+    data,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    }
+  )
 }


### PR DESCRIPTION
## Summary
- switch frontend API calls to use `process.env.NEXT_PUBLIC_API_URL`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684afd1a9d5c83338e7387d2d49d5426